### PR TITLE
order translations by frequency

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -8,7 +8,6 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.mongodb.org/mongo-driver/x/bsonx"
 )
 
@@ -42,12 +41,7 @@ func InitDB(ctx context.Context, client mongo.Client) error {
 //Insert inserts the translation into the mongoDB
 func Insert(ctx context.Context, data bson.D) error {
 
-	opts := options.Update().SetUpsert(true)
-
-	update := bson.D{
-		{Key: "$set", Value: data},
-	}
-	_, err := collection.UpdateOne(ctx, data, update, opts)
+	_, err := collection.InsertOne(ctx, data)
 
 	if err != nil {
 		log.Fatal(err)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ services:
    keyboard:
       build: .
       container_name: keyboard
+      depends_on:
+        - mongo
       ports:
       - '127.0.0.1:8080:8080'
       network_mode: "host"

--- a/importer/importer.go
+++ b/importer/importer.go
@@ -13,8 +13,12 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 )
 
+var counter int
+
 //Import reads text files in the resources folder and inserts into mongodb
 func Import(ctx context.Context) error {
+
+	counter = 0
 
 	//import
 	for i := 1; i <= 6; i++ {
@@ -52,11 +56,13 @@ func addTranslations(ctx context.Context, translations chinese.Translations) {
 	for _, item := range translations.Items {
 
 		value := bson.D{
+			{Key: "_id", Value: counter},
 			{Key: "pinyin", Value: item.Pinyin},
 			{Key: "simplified", Value: item.Simplified},
 			{Key: "traditional", Value: item.Traditional},
 		}
 
+		counter++
 		db.Insert(ctx, value)
 	}
 }


### PR DESCRIPTION
insert frequency as ID for characters in mongo
sort by this frequency when returning translations
also changed upsert into insert as upsert no longer required.